### PR TITLE
Silence warning for missing path for `vtcol` binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "vtcol"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license     = "GPL-3.0"
 
 [[bin]]
 name        = "vtcol"
+path        = "src/vtcol.rs"
 test        = false
 doc         = false
 


### PR DESCRIPTION
vtcol.rs should probably be main.rs, but explicitly setting the
non-standard path also silences the warning. (src/bin would also work)